### PR TITLE
Fix: add i18n containers namespaces and loader

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -7,8 +7,16 @@ module.exports = {
     '*': ['common', 'site'],
     '/': ['page-home'],
     '/about': ['page-about'],
-    '/links': ['page-links'],
+    '/links': ['page-links', 'container-LinksList'],
   },
   logBuild: process.env.NODE_ENV === 'development',
-  loadLocaleFrom: (lang, ns) => import(`./${localesFolder}/${lang}/${ns}.json`).then((m) => m.default),
+  loadLocaleFrom: (lang, ns) => {
+    // Containers
+    if (ns.startsWith('container-')) {
+      const [_, containerName] = ns.split('-');
+      return import(`./src/containers/${containerName}/${localesFolder}/${lang}.json`).then((m) => m.default);
+    }
+    // Globals
+    return import(`./${localesFolder}/${lang}/${ns}.json`).then((m) => m.default);
+  },
 };

--- a/locales/en/page-links.json
+++ b/locales/en/page-links.json
@@ -3,10 +3,5 @@
         "title": "Links",
         "description": "Some links I love"
     },
-    "introduction": "Below a list of links",
-    "link-count": {
-        "0": "No link yet",
-        "1": "One link available",
-        "other": "{{count}} links !"
-    }
+    "introduction": "Below a list of links"
 }

--- a/locales/fr/page-links.json
+++ b/locales/fr/page-links.json
@@ -3,10 +3,5 @@
         "title": "Liens",
         "description": "Des sites que j'adore"
     },
-    "introduction": "Une liste de liens",
-    "link-count": {
-        "0": "Aucun lien pour le moment",
-        "1": "Un lien disponible",
-        "other": "{{count}} liens disponibles"
-    }
+    "introduction": "Une liste de liens"
 }

--- a/src/containers/LinksList/locales/en.json
+++ b/src/containers/LinksList/locales/en.json
@@ -1,0 +1,7 @@
+{
+    "link-count": {
+        "0": "No link yet",
+        "1": "One link available",
+        "other": "{{count}} links !"
+    }
+}

--- a/src/containers/LinksList/locales/fr.json
+++ b/src/containers/LinksList/locales/fr.json
@@ -1,0 +1,7 @@
+{
+    "link-count": {
+        "0": "Aucun lien pour le moment",
+        "1": "Un lien disponible",
+        "other": "{{count}} liens disponibles"
+    }
+}


### PR DESCRIPTION
Let use locales files in containers folder to keep them close to their source.

- add i18n locales file load based on namespace prefixed with `container-`
- refactor locales translations for existing containers